### PR TITLE
Add acquisition search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Config your user_key, debug somewhere like development.rb, Recommended directory
     Crunchbase::API.key   = 'user_key'
     Crunchbase::API.debug = false
 
-## Search Organization OR Person OR Product OR IPO
+## Search Organization OR Person OR Product OR IPO OR Acquisitions
 
 Retrieve the way, Please use Search Class. The Search Will Return a list consisting of objects of the OrganizationSummary | PersonSummary | ProductSummary type. Example:
 
@@ -61,6 +61,10 @@ Retrieve the way, Please use Search Class. The Search Will Return a list consist
     response = Crunchbase::Model::Search.search({}, 'ipos')
 
     response.results.each { |i| i.name }
+
+    Query Acquisition
+
+    response = Crunchbase::Model::Search.search({}, 'acquisitions')
 
 ## Get Organization && RelationShips
 

--- a/lib/crunchbase/model/entity.rb
+++ b/lib/crunchbase/model/entity.rb
@@ -124,7 +124,7 @@ module Crunchbase::Model
     end
 
     def self.get_model_name(resource_list)
-      return nil unless ['organizations', 'people', 'products', 'ipos'].include?(resource_list)
+      return nil unless ['organizations', 'people', 'products', 'ipos', 'acquisitions'].include?(resource_list)
 
       case resource_list
       when 'organizations'
@@ -135,6 +135,8 @@ module Crunchbase::Model
         ProductSummary
       when 'ipos'
         Ipo
+      when 'acquisitions'
+        Acquisition
       else
         nil
       end

--- a/lib/crunchbase/model/simple_organization.rb
+++ b/lib/crunchbase/model/simple_organization.rb
@@ -11,7 +11,7 @@ module Crunchbase::Model
       }
 
       %w[created_at updated_at].each { |v|
-        instance_variable_set("@#{v}", Time.at(json[v]))
+        instance_variable_set("@#{v}", Time.at(json[v])) unless json[v].nil?
       }
     end
 


### PR DESCRIPTION
Make acquisitions searchable. Also added nil guard to simple organizations. Some Acquisitions I searched for gave me simple organization instances that would error since they had nils for updated_at/created_at.
