### PR TITLE
API call timeouts if no UA string is provided

### DIFF
--- a/lib/crunchbase/api.rb
+++ b/lib/crunchbase/api.rb
@@ -151,7 +151,7 @@ module Crunchbase
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true if uri.scheme == 'https'
         response = http.start do |h|
-          h.request Net::HTTP::Get.new(uri.request_uri)
+          h.request Net::HTTP::Get.new(uri.request_uri, {'User-Agent' => 'crunchbase-ruby-library'})
         end
 
         case response


### PR DESCRIPTION
Was getting `Timeout::Error: execution expired` while the same URI worked okay when accessed via Postman or browser. Adding a UA string seems to have fixed it.